### PR TITLE
denser: use 'in-addr.arpa' instead of 'IN-ADDR.ARPA'

### DIFF
--- a/denser/dense.c
+++ b/denser/dense.c
@@ -255,7 +255,7 @@ main( int argc, char* argv[] )
     }
 
     if ( typenum == DNSR_TYPE_PTR ) {
-	if (( name = dnsr_reverse_ip( dnsr, name, "IN-ADDR.ARPA" )) == NULL ) {
+	if (( name = dnsr_reverse_ip( dnsr, name, "in-addr.arpa" )) == NULL ) {
 	    dnsr_perror( dnsr, "dnsr_reverse_ip" );
 	    exit( 1 );
 	}

--- a/denser/query.c
+++ b/denser/query.c
@@ -311,7 +311,7 @@ dnsr_ntoptr( DNSR *dnsr, const void *src, char *suffix )
     }
     DEBUG( fprintf( stderr, "inet_ntop -> %s\n", temp ));
 
-    return( dnsr_reverse_ip( dnsr, temp, suffix ? suffix : "IN-ADDR.ARPA" ));
+    return( dnsr_reverse_ip( dnsr, temp, suffix ? suffix : "in-addr.arpa" ));
 }
 
     char *


### PR DESCRIPTION
Both are correct and nameservers _must_ treat them identically,
but there's a widespread bug in Cisco firewalls that results in
broken reverse lookups when the request is uppercase.

Stupid Cisco.
