### PR TITLE
Fix simta_max_message_size comparison

### DIFF
--- a/receive.c
+++ b/receive.c
@@ -1568,7 +1568,7 @@ f_data( struct receive_data *r )
 	    }
 	}
 
-	if (( read_err == NO_ERROR ) && ( simta_max_message_size != 0 ) &&
+	if (( read_err == NO_ERROR ) && ( simta_max_message_size > 0 ) &&
 		(( data_wrote + line_len + 1 ) > simta_max_message_size )) {
 	    /* If we're going to reach max size, continue reading lines
 	     * until the '.' otherwise, check message size.


### PR DESCRIPTION
The default value is -1, which should result in no limit but instead
resulted in every message being rejected when no value was explicitly
set.
