### PR TITLE
Try to log the SASL username on errors

### DIFF
--- a/receive.c
+++ b/receive.c
@@ -525,7 +525,7 @@ smtp_write_banner( struct receive_data *r, int reply_code, char *msg,
 	break;
 
     case 535:
-	boilerplate = "Invalid initial-response arugment for mechanism";
+	boilerplate = "Invalid initial-response argument for mechanism";
 	break;
 
     case 538:
@@ -2467,7 +2467,7 @@ f_auth( struct receive_data *r )
 	 * reply.
 	 */
 	syslog( LOG_ERR, "Auth [%s] %s: %s: "
-		"Invaid initial-response argument for mechanism %s",
+		"Invalid initial-response argument for mechanism %s",
 		inet_ntoa( r->r_sin->sin_addr ), r->r_remote_hostname, 
 		r->r_auth_id, r->r_av[ 1 ] );
 	return( smtp_write_banner( r, 535, NULL, NULL ));


### PR DESCRIPTION
With the patch:
simta[18527.1381783028]: Auth [67.194.39.165] 67-194-39-165.wireless.umnet.umich.edu: ezekielh: sasl_start_server: SASL(-13): authentication failure: Password verification failed

Without:
simta[20532.1381783738]: Auth [67.194.39.165] 67-194-39-165.wireless.umnet.umich.edu: (null): sasl_start_server: SASL(-13): authentication failure: Password verification failed

Unlike the success path I didn't check the return value of sasl_getprop, but that should be okay because we're on the error path and are going to fail the connection regardless.
